### PR TITLE
Version number referring to Open Yesterday repository

### DIFF
--- a/modules/ui/version.js
+++ b/modules/ui/version.js
@@ -26,7 +26,7 @@ export function uiVersion(context) {
             .append('a')
             .attr('target', '_blank')
             .attr('tabindex', -1)
-            .attr('href', 'https://github.com/openstreetmap/iD')
+            .attr('href', 'https://github.com/oSoc19/Open-Yesterday-iD-Editor')
             .text(currVersion);
 
         // only show new version indicator to users that have used iD before


### PR DESCRIPTION
Solution for: https://github.com/oSoc19/Open-Yesterday-iD-Editor/issues/6

I edited the version number hyperlink (present in the right bottom corner) to refer to our Open Yesterday repo.